### PR TITLE
Use `signingName` while signing request if present

### DIFF
--- a/src/AWS/Internal/V4.elm
+++ b/src/AWS/Internal/V4.elm
@@ -209,7 +209,7 @@ credentialScope : Posix -> Credentials -> Service -> String
 credentialScope date creds service =
     [ date |> formatPosix |> String.slice 0 8
     , Service.region service
-    , service.endpointPrefix
+    , Maybe.withDefault service.endpointPrefix service.signingName
     , "aws4_request"
     ]
         |> String.join "/"
@@ -229,7 +229,7 @@ signature creds service date toSign =
         |> Bytes.fromUTF8
         |> digest (formatPosix date |> String.slice 0 8)
         |> digest (Service.region service)
-        |> digest service.endpointPrefix
+        |> digest (Maybe.withDefault service.endpointPrefix service.signingName)
         |> digest "aws4_request"
         |> digest toSign
         |> Hex.fromByteList


### PR DESCRIPTION
I received an error `InvalidSignatureException` for an [Amazon IOT service](https://github.com/aws/aws-sdk-js/blob/master/apis/iot-2015-05-28.normal.json) which has a `signingName` (different from `endpointPrefix`).

Right now we can define the `signingName` while creating a service using `withSigningName` but it seems like the `signingName` is not used anywhere inside V4 module.

Based on my understanding it should be used to sign the request instead of `endpointPrefix` if it's present.