### PR TITLE
Add session token first so 

### DIFF
--- a/src/AWS/Internal/V4.elm
+++ b/src/AWS/Internal/V4.elm
@@ -79,8 +79,8 @@ sign service creds date req =
         { method = req.method
         , headers =
             headers service date req.body req.headers
-                |> addAuthorization service creds date req
                 |> addSessionToken creds
+                |> addAuthorization service creds date req
                 |> List.map (\( key, val ) -> Http.header key val)
         , url = AWS.Internal.UrlBuilder.url service req
         , body = AWS.Internal.Body.toHttp req.body


### PR DESCRIPTION
`x-amz-security-token` header created by the `addSessionToken` needs to be in the signed headers.

In fact I think, all headers should be added first and then the signed headers should be created.